### PR TITLE
Add gnome-common to indicator-gtk* builds

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -89,6 +89,7 @@ parts:
     plugin: autotools
     build-packages:
       - at-spi2-core
+      - gnome-common
       - gobject-introspection
       - intltool
       - libdbus-glib-1-dev

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -47,6 +47,7 @@ parts:
     source: lp:libappindicator
     build-packages:
       - at-spi2-core
+      - gnome-common
       - gobject-introspection
       - intltool
       - libdbus-glib-1-dev


### PR DESCRIPTION
Fix the build.

libappindicator requires gnome-common to run autogen.sh.
Although it attempts to only build mono support when the relevant packages are installed its detection is buggy, and it fails to build without the required mono packages installed.